### PR TITLE
Try WIC as fallback on load error in stbi

### DIFF
--- a/src/tabs/viewer.cpp
+++ b/src/tabs/viewer.cpp
@@ -235,7 +235,7 @@ LoadLibraryTexture (image_s& image)
     stbi_image_free (pixels);
   }
 
-  else if (decoder == ImageDecoder_WIC)
+  if (!succeeded || decoder == ImageDecoder_WIC)
   {
     if (SUCCEEDED (
         DirectX::LoadFromWICFile (


### PR DESCRIPTION
When stbi fails, try WIC for image files that have an incorrect file-ending and other edge cases where WIC might offer wider support