### PR TITLE
Initial HDR support

### DIFF
--- a/resources/shaders/imgui_vtx_shader.hlsl
+++ b/resources/shaders/imgui_vtx_shader.hlsl
@@ -44,14 +44,16 @@ struct VS_INPUT
   float2 pos : POSITION;
   float2 uv  : TEXCOORD0;
   float4 col : COLOR0; // ImU32
+  uint   vI  : SV_VERTEXID;
 };
 
 struct PS_INPUT
 {
-  float4 pos : SV_POSITION;
-  float2 uv  : TEXCOORD0;
-  float4 col : COLOR0; // ImU32
-  float4 lum : COLOR1; // constant_buffer->luminance_scale
+  float4 pos     : SV_POSITION;
+  float2 uv      : TEXCOORD0;
+  float4 col     : COLOR0; // ImU32
+  float4 lum     : COLOR1; // constant_buffer->luminance_scale
+  float  hdr_img : COLOR2;
 };
 
 PS_INPUT main (VS_INPUT input)
@@ -60,9 +62,24 @@ PS_INPUT main (VS_INPUT input)
   
   output.pos  = mul ( ProjectionMatrix,
                         float4 (input.pos.xy, 0.f, 1.f) );
-  output.col = input.col;
-  output.uv  = input.uv; // Texture coordinates
   output.lum = Luminance.xyzw;
+
+  // Reserved texcoords for HDR content passthrough
+  if (all (input.uv < -1024.0f))
+  {
+    output.uv      = float2 (input.vI >= 1 &&
+                             input.vI <  3,
+                             input.vI >> 1);
+    output.col     = float4 (1.0f, 1.0f, 1.0f, 1.0f);
+    output.hdr_img = 1.0f;
+  }
+
+  else
+  {
+    output.uv      = input.uv; // Texture coordinates
+    output.col     = input.col;
+    output.hdr_img = 0.0f;
+  }
 
   return output;
 }

--- a/src/SKIV.cpp
+++ b/src/SKIV.cpp
@@ -2971,10 +2971,14 @@ bool CreateDeviceD3D (HWND hWnd)
     // HDR formats
     if (_registry._RendererCanHDR && _registry.iHDRMode > 0)
     {
+#ifdef SKIV_HDR10_SUPPORT
       if      (_registry.iHDRMode == 2)
         dxgi_format = DXGI_FORMAT_R16G16B16A16_FLOAT; // scRGB (16 bpc)
       else
         dxgi_format = DXGI_FORMAT_R10G10B10A2_UNORM;  // HDR10 (10 bpc)
+#else
+      dxgi_format = DXGI_FORMAT_R16G16B16A16_FLOAT; // scRGB (16 bpc)
+#endif
     }
 
     // SDR formats

--- a/src/tabs/settings.cpp
+++ b/src/tabs/settings.cpp
@@ -419,12 +419,14 @@ SKIF_UI_Tab_DrawSettings (void)
           _registry.regKVHDRMode.putData (         _registry.iHDRMode);
           RecreateSwapChains = true;
         }
+#ifdef SKIV_HDR10_SUPPORT
         ImGui::SameLine        ( );
         if (ImGui::RadioButton ("HDR10 (10 bpc)", &_registry.iHDRMode, 1))
         {
           _registry.regKVHDRMode.putData (         _registry.iHDRMode);
           RecreateSwapChains = true;
         }
+#endif
         ImGui::SameLine        ( );
         if (ImGui::RadioButton ("scRGB (16 bpc)", &_registry.iHDRMode, 2))
         {


### PR DESCRIPTION
+ Added support for tonemapping HDR to SDR
+ Added HDR luminance info
+ Added .jxr to file open dialog filter
+ Removed HDR10 (from the control panel, though remnants still exist)
 > HDR10 is completely impractical for this because content can be in wider colorspaces.

In order to draw HDR content without having ImGui do the normal 2.2/sRGB gamma, texture coordinates **-2048.0,-2048.0** are passed to `ImGui::Image (...)`. This indicates that the source texture is linear. It is a stupid way of doing things, but it requires zero modification to ImGui, so sloppy confusing vertex and pixel shaders will do. These shaders were already a total mess :)