### PR TITLE
Add support for pasting screenshots that SK copies to the clipboard

### DIFF
--- a/include/utility/droptarget.hpp
+++ b/include/utility/droptarget.hpp
@@ -97,7 +97,7 @@ public:
 
 #ifdef _DEBUG
           TCHAR szFormatName[256];
-          GetClipboardFormatName (s_fmtSupported.cfFormat, szFormatName, 256);
+          GetClipboardFormatNameW (s_fmtSupported.cfFormat, szFormatName, 256);
           PLOG_VERBOSE << "Supported format: " << s_fmtSupported.cfFormat << " - " << szFormatName;
 #endif
 

--- a/include/utility/utility.h
+++ b/include/utility/utility.h
@@ -12,6 +12,7 @@
 #include <vector>
 #include <shellapi.h>
 #include <stdexcept>
+#include <DirectXTex.h>
 
 #pragma comment(lib, "wininet.lib")
 
@@ -184,7 +185,8 @@ int             SKIF_Util_RegisterApp                 (bool force   = false);
 bool            SKIF_Util_IsMPOsDisabledInRegistry    (bool refresh = false);
 void            SKIF_Util_GetMonitorHzPeriod          (HWND hwnd, DWORD dwFlags, DWORD& dwPeriod);
 bool            SKIF_Util_SetClipboardData            (const std::wstring_view& data);
-std::wstring    SKIF_Util_GetClipboardData            (void);
+std::wstring    SKIF_Util_GetClipboardTextData        (void);
+DirectX::Image  SKIF_Util_GetClipboardBitmapData      (void);
 std::wstring    SKIF_Util_AddEnvironmentBlock         (const void* pEnvBlock, const std::wstring& varName, const std::wstring& varValue);
 void            SKIF_Util_FileExplorer_SelectFile     (PCWSTR filePath);
 std::string     SKIF_Util_GetWindowMessageAsStr       (UINT msg);

--- a/include/utility/utility.h
+++ b/include/utility/utility.h
@@ -34,6 +34,19 @@
 
 // Stuff
 
+
+extern UINT          CF_HTML;        // Registered clipboard format for the "HTML Format"
+typedef unsigned int ClipboardData;  // -> enum ClipboardData_
+
+enum ClipboardData_
+{
+  ClipboardData_None        = 0,
+  ClipboardData_TextANSI    = 1 << 0, // Text        (ANSI)
+  ClipboardData_TextUnicode = 1 << 1, // Text        (Unicode)
+  ClipboardData_HTML        = 1 << 2, // HTML Format (ANSI)
+  ClipboardData_Bitmap      = 1 << 3, // Bitmap
+};
+
 enum UITab {
   UITab_None,
   UITab_Viewer,
@@ -185,7 +198,9 @@ int             SKIF_Util_RegisterApp                 (bool force   = false);
 bool            SKIF_Util_IsMPOsDisabledInRegistry    (bool refresh = false);
 void            SKIF_Util_GetMonitorHzPeriod          (HWND hwnd, DWORD dwFlags, DWORD& dwPeriod);
 bool            SKIF_Util_SetClipboardData            (const std::wstring_view& data);
-std::wstring    SKIF_Util_GetClipboardTextData        (void);
+std::string     SKIF_Util_GetClipboardTextData        (void);
+std::wstring    SKIF_Util_GetClipboardTextDataW       (void);
+std::string     SKIF_Util_GetClipboardHTMLData        (void);
 DirectX::Image  SKIF_Util_GetClipboardBitmapData      (void);
 std::wstring    SKIF_Util_AddEnvironmentBlock         (const void* pEnvBlock, const std::wstring& varName, const std::wstring& varValue);
 void            SKIF_Util_FileExplorer_SelectFile     (PCWSTR filePath);

--- a/src/SKIV.cpp
+++ b/src/SKIV.cpp
@@ -2551,7 +2551,19 @@ wWinMain ( _In_     HINSTANCE hInstance,
       // Optionally we'd filter out the data here too, but it would just
       //   duplicate the same processing we're already doing in viewer.cpp
       if (hotkeyCtrlV && ! ImGui::IsAnyItemActive ( )) // && ! ImGui::IsAnyItemFocused ( )
-        dragDroppedFilePath = SKIF_Util_GetClipboardData ( );
+      {
+        auto img = SKIF_Util_GetClipboardBitmapData ();
+
+        if (img.format != DXGI_FORMAT_UNKNOWN)
+        {
+          //MessageBox (nullptr, L"There's image data!", L"Cool", MB_OK);
+        }
+
+        else
+        {
+          dragDroppedFilePath = SKIF_Util_GetClipboardTextData ( );
+        }
+      }
 
       // End the main ImGui window
       ImGui::End ( );

--- a/src/tabs/viewer.cpp
+++ b/src/tabs/viewer.cpp
@@ -848,7 +848,7 @@ LoadLibraryTexture (image_s& image)
         size_t   imageSize = width * height * desired_channels * sizeof (pixel_size);
         uint8_t* pDest     = img.GetImage(0, 0, 0)->pixels;
         memcpy  (pDest, pixels, imageSize);
-      
+
         succeeded = true;
       }
 
@@ -876,8 +876,8 @@ LoadLibraryTexture (image_s& image)
             DirectX::DDS_FLAGS_PERMISSIVE,
               &meta, img)))
     {
-      const DXGI_FORMAT final_format  = DXGI_FORMAT_R8G8B8A8_UNORM;
-      DirectX::ScratchImage temp_img  = { };
+      const DXGI_FORMAT final_format = DXGI_FORMAT_R8G8B8A8_UNORM;
+      DirectX::ScratchImage temp_img = { };
 
       succeeded = true;
 
@@ -908,6 +908,8 @@ LoadLibraryTexture (image_s& image)
         std::swap (img, temp_img);
         meta = img.GetMetadata ( );
       }
+
+      meta.format = DirectX::MakeSRGB (DirectX::MakeTypeless (meta.format));
     }
   }
 
@@ -992,6 +994,8 @@ LoadLibraryTexture (image_s& image)
     XMVECTOR vMaxCLL = g_XMZero;
     XMVECTOR vMaxLum = g_XMZero;
     XMVECTOR vMinLum = g_XMOne;
+
+    double dLumAccum = 0.0;
 
     static constexpr float FLT16_MIN = 0.0000000894069671630859375f;
 
@@ -1094,6 +1098,9 @@ LoadLibraryTexture (image_s& image)
         vMinLum =
           XMVectorMin (vMinLum, vColorXYZ);
 
+        dLumAccum +=
+          XMVectorGetY (v);
+
         //lumTotal +=
         //  logf ( std::max (0.000001f, 0.000001f + XMVectorGetY (v)) ),
         //++N;
@@ -1145,13 +1152,15 @@ LoadLibraryTexture (image_s& image)
       fMinLum = 0.0f;
     }
 
-    // Not implemented yet, need to implement histogram
-    image.light_info.avg_nits = std::numeric_limits <float>::infinity ();
-
     image.light_info.max_cll      = fMaxCLL;
     image.light_info.max_cll_name = cMaxChannel;
     image.light_info.max_nits     = fMaxLum * 80.0f; // scRGB
     image.light_info.min_nits     = fMinLum * 80.0f; // scRGB
+
+    // Not a great measure of average, but it's sufficient for now
+    image.light_info.avg_nits     = 80.0f * static_cast <float> (
+      dLumAccum / static_cast <double> (meta.width * meta.height)
+    );
   }
 
   HRESULT hr =
@@ -1901,6 +1910,7 @@ SKIF_UI_Tab_DrawViewer (void)
 
       static const char szLightLabels [] = "MaxCLL (scRGB): \n"
                                            "Max Luminance: \n"
+                                           "Avg Luminance: \n"
                                            "Min Luminance: ";
       char     szLightUnits  [512] = { };
       char     szLightLevels [512] = { };
@@ -1908,11 +1918,14 @@ SKIF_UI_Tab_DrawViewer (void)
       sprintf (szLightUnits, (const char*)
                            u8"(%c)\n"
                            u8"cd / m\u00b2\n" // Unicode: Superscript Two
+                           u8"cd / m\u00b2\n"
                            u8"cd / m\u00b2", cover.light_info.max_cll_name);
       sprintf (szLightLevels, "%.3f \n"
-                              "%.2f \n"
-                              "%.2f ",  cover.light_info.max_cll,
+                              "%.3f \n"
+                              "%.3f \n"
+                              "%.3f ",  cover.light_info.max_cll,
                                         cover.light_info.max_nits,
+                                        cover.light_info.avg_nits,
                                         cover.light_info.min_nits);
 
       auto orig_pos =

--- a/src/tabs/viewer.cpp
+++ b/src/tabs/viewer.cpp
@@ -436,7 +436,10 @@ SaveTempImage (std::wstring_view source, std::wstring_view filename)
       }
     }
 
-    PLOG_ERROR_IF(! success) << "Failed to process the new cover image!";
+    else {
+      PostMessage (SKIF_Notify_hWnd, WM_SKIF_IMAGE, 0x0, static_cast<LPARAM> (success));
+      PLOG_ERROR << "Failed to process the new cover image!";
+    }
 
     PLOG_INFO  << "Finished downloading web image asynchronously...";
     
@@ -909,7 +912,7 @@ LoadLibraryTexture (image_s& image)
         meta = img.GetMetadata ( );
       }
 
-      meta.format = DirectX::MakeSRGB (DirectX::MakeTypeless (meta.format));
+      //meta.format = DirectX::MakeSRGB (DirectX::MakeTypeless (meta.format));
     }
   }
 
@@ -1824,12 +1827,15 @@ SKIF_UI_Tab_DrawViewer (void)
     ImGui::SetScrollHereX ( );
   }
 
-  // Using 4.975f and 0.075f to work around some floating point shenanigans
-  if (     ImGui::GetIO().MouseWheel > 0 && cover.zoom < 4.975f)
-    cover.zoom += 0.05f;
+  if (cover.pRawTexSRV.p != nullptr)
+  {
+    // Using 4.975f and 0.075f to work around some floating point shenanigans
+    if (     ImGui::GetIO().MouseWheel > 0 && cover.zoom < 4.975f)
+      cover.zoom += 0.05f;
 
-  else if (ImGui::GetIO().MouseWheel < 0 && cover.zoom > 0.075f)
-    cover.zoom -= 0.05f;
+    else if (ImGui::GetIO().MouseWheel < 0 && cover.zoom > 0.075f)
+      cover.zoom -= 0.05f;
+  }
 
 #pragma endregion
 

--- a/src/utility/utility.cpp
+++ b/src/utility/utility.cpp
@@ -28,6 +28,8 @@
 #include <utility/registry.h>
 #include <HybridDetect.h>
 
+UINT CF_HTML = NULL;
+
 std::vector<HANDLE> vWatchHandles[UITab_ALL];
 INT64               SKIF_TimeInMilliseconds = 0;
 
@@ -2327,12 +2329,38 @@ SKIF_Util_SetClipboardData (const std::wstring_view& data)
   return result;
 }
 
-std::wstring
+std::string
 SKIF_Util_GetClipboardTextData (void)
+{
+  std::string result = { };
+
+  if (true) // OpenClipboard (SKIF_ImGui_hWnd)
+  {
+    HGLOBAL hGlobal = GetClipboardData (CF_TEXT);
+
+    if (hGlobal)
+    {
+      const char* pszSource = static_cast<const char*> (GlobalLock (hGlobal));
+
+      if (pszSource != nullptr)
+      {
+        result = std::string (pszSource);
+        GlobalUnlock (hGlobal);
+      }
+    }
+
+    //CloseClipboard ( );
+  }
+
+  return result;
+}
+
+std::wstring
+SKIF_Util_GetClipboardTextDataW (void)
 {
   std::wstring result = { };
 
-  if (OpenClipboard (SKIF_ImGui_hWnd))
+  if (true) // OpenClipboard (SKIF_ImGui_hWnd)
   {
     HGLOBAL hGlobal = GetClipboardData (CF_UNICODETEXT);
 
@@ -2347,11 +2375,38 @@ SKIF_Util_GetClipboardTextData (void)
       }
     }
 
-    CloseClipboard ( );
+    //CloseClipboard ( );
   }
 
   return result;
 }
+
+std::string
+SKIF_Util_GetClipboardHTMLData (void)
+{
+  std::string result = { };
+
+  if (true) // OpenClipboard (SKIF_ImGui_hWnd)
+  {
+    HGLOBAL hGlobal = GetClipboardData (CF_HTML);
+
+    if (hGlobal)
+    {
+      const char* pszSource = static_cast<const char*> (GlobalLock (hGlobal));
+
+      if (pszSource != nullptr)
+      {
+        result = std::string (pszSource);
+        GlobalUnlock (hGlobal);
+      }
+    }
+
+    //CloseClipboard ( );
+  }
+
+  return result;
+}
+
 
 #include <wincodec.h>
 
@@ -2360,7 +2415,7 @@ SKIF_Util_GetClipboardBitmapData (void)
 {
   DirectX::Image img = { };
 
-  if (OpenClipboard (SKIF_ImGui_hWnd))
+  if (true) // OpenClipboard (SKIF_ImGui_hWnd)
   {
     HGLOBAL hGlobal = GetClipboardData (CF_DIBV5);
 
@@ -2374,7 +2429,17 @@ SKIF_Util_GetClipboardBitmapData (void)
         int offset =
           bmp5hdr->bV5Size + bmp5hdr->bV5ClrUsed * sizeof (RGBQUAD);
 
-        if (bmp5hdr->bV5Compression == BI_BITFIELDS)
+        PLOG_VERBOSE << "bmp5hdr->bV5Compression: " <<
+             ((bmp5hdr->bV5Compression == BI_JPEG)      ? "JPEG"         :
+              (bmp5hdr->bV5Compression == BI_PNG)       ? "BI_PNG"       :
+              (bmp5hdr->bV5Compression == BI_RGB)       ? "BI_RGB"       :
+              (bmp5hdr->bV5Compression == BI_RLE4)      ? "BI_RLE4"      :
+              (bmp5hdr->bV5Compression == BI_RLE8)      ? "BI_RLE8"      :
+              (bmp5hdr->bV5Compression == BI_BITFIELDS) ? "BI_BITFIELDS" :
+                                                          "Unknown"     );
+
+        if (bmp5hdr->bV5Compression == BI_BITFIELDS ||
+            bmp5hdr->bV5Compression == BI_RGB)
         {
           offset += 12;
 
@@ -2410,6 +2475,7 @@ SKIF_Util_GetClipboardBitmapData (void)
             {
               extern std::wstring dragDroppedFilePath;
               dragDroppedFilePath = L"clipboard.tiff";
+              PLOG_VERBOSE << "Successfully received and saved image data from the clipboard!";
             }
           }
         }
@@ -2418,7 +2484,7 @@ SKIF_Util_GetClipboardBitmapData (void)
       }
     }
 
-    CloseClipboard ( );
+    //CloseClipboard ( );
   }
 
   return img;


### PR DESCRIPTION
I am not really happy with this solution, but it implements everything necessary.

There's a temporary file created because SKIV isn't really capable of loading arbitrary images from memory at the moment. I used TIFF because it encodes quickly and produces a small file.

Ideally, SKIV would be able to take the `DirectX::Image` created by copying the contents of the clipboard and load it somehow, without requiring a trip to the disk. But that needs redesign that I'm not familiar enough with the code to do.