### PR TITLE
Initial HDR display tone mapping support

### DIFF
--- a/include/imgui/imgui_impl_dx11.h
+++ b/include/imgui/imgui_impl_dx11.h
@@ -30,4 +30,32 @@ IMGUI_IMPL_API void     ImGui_ImplDX11_RenderDrawData(ImDrawData* draw_data);
 IMGUI_IMPL_API void     ImGui_ImplDX11_InvalidateDeviceObjects();
 IMGUI_IMPL_API bool     ImGui_ImplDX11_CreateDeviceObjects();
 
+
+#ifndef SKIF_CUSTOM_IMGUI_DX11_VIEWPORT_STRUCT
+#define SKIF_CUSTOM_IMGUI_DX11_VIEWPORT_STRUCT
+#include <dxgi1_2.h>
+#include <dxgi1_6.h>
+#include <d3d11.h>
+
+struct ImGui_ImplDX11_ViewportData
+{
+    IDXGISwapChain1*        SwapChain;
+    ID3D11RenderTargetView* RTView;
+    UINT                    PresentCount;
+    HANDLE                  WaitHandle;
+    int                     SDRMode;       // 0 = 8 bpc,   1 = 10 bpc,      2 = 16 bpc scRGB
+    FLOAT                   SDRWhiteLevel; // SDR white level in nits for the display
+    int                     HDRMode;       // 0 = No HDR,  1 = 10 bpc HDR,  2 = 16 bpc scRGB HDR
+    bool                    HDR;
+    FLOAT                   HDRLuma;
+    FLOAT                   HDRMinLuma;
+    DXGI_OUTPUT_DESC1       DXGIDesc;
+    DXGI_FORMAT             DXGIFormat;
+
+     ImGui_ImplDX11_ViewportData (void) {            SwapChain  = nullptr;   RTView  = nullptr;   WaitHandle  = 0;  PresentCount = 0; SDRMode = 0; SDRWhiteLevel = 80.0f; HDRMode = 0; HDR = false; HDRLuma = 0.0f; HDRMinLuma = 0.0f; DXGIDesc = {   }; DXGIFormat = DXGI_FORMAT_UNKNOWN; }
+    ~ImGui_ImplDX11_ViewportData (void) { IM_ASSERT (SwapChain == nullptr && RTView == nullptr && WaitHandle == 0); }
+};
+#endif
+
+
 #endif // #ifndef IMGUI_DISABLE

--- a/resources/shaders/imgui_pix_shader.hlsl
+++ b/resources/shaders/imgui_pix_shader.hlsl
@@ -626,11 +626,16 @@ float4 main (PS_INPUT input) : SV_Target
         case SKIV_TONEMAP_TYPE_NORMALIZE_TO_CLL:   Y_out = TonemapSDR  (Y_in, cML, 1.0f); break;
         case SKIV_TONEMAP_TYPE_MAP_CLL_TO_DISPLAY: Y_out = TonemapHDR  (Y_in, cML, dML);  break;
       }
-      
-      if (Y_out > 0.0)
+
+      if (Y_out > 0.0 && Y_in > 0.0)
       {
-        out_col.rgb *= (Y_out / Y_in);
+        xyz.xyz *= (Y_out / Y_in);
       }
+
+      else
+        xyz.xyz = (0.0).xxx;
+
+      out_col.rgb = XYZtoRec709 (xyz);
     }
 
     // Manipulate the alpha channel a bit...

--- a/src/SKIV.cpp
+++ b/src/SKIV.cpp
@@ -1729,12 +1729,12 @@ wWinMain ( _In_     HINSTANCE hInstance,
       // Begin Large Mode
 #pragma region UI: Large Mode
 
-      // TAB: Library
+      // TAB: Viewer
       if (SKIF_Tab_Selected == UITab_Viewer ||
           SKIF_Tab_ChangeTo == UITab_Viewer)
       {
         ImGui::PushStyleVar (ImGuiStyleVar_FramePadding, ImVec2());
-        bool show = SKIF_ImGui_BeginMainChildFrame (ImGuiWindowFlags_NoScrollWithMouse);
+        bool show = SKIF_ImGui_BeginMainChildFrame (ImGuiWindowFlags_NoScrollWithMouse | ImGuiWindowFlags_NoScrollbar);
         ImGui::PopStyleVar  ( );
 
         /*

--- a/src/SKIV.cpp
+++ b/src/SKIV.cpp
@@ -1593,6 +1593,7 @@ wWinMain ( _In_     HINSTANCE hInstance,
         ImGui::SetNextWindowSizeConstraints (wnd_minimum_size, ImVec2 (FLT_MAX, FLT_MAX));
 
       ImGui::PushStyleVar (ImGuiStyleVar_WindowPadding, ImVec2());
+      ImGui::PushStyleVar (ImGuiStyleVar_WindowBorderSize, 0.0f); // Disable ImGui's 1 px window border
       ImGui::Begin (SKIV_WINDOW_TITLE_HASH,
                        nullptr,
                        //ImGuiWindowFlags_NoResize          |
@@ -1603,7 +1604,7 @@ wWinMain ( _In_     HINSTANCE hInstance,
                       // ImGuiWindowFlags_NoMove              // This was added in #8bf06af, but I am unsure why.
                       // The only comment is that it was DPI related? This prevents Ctrl+Tab from moving the window so must not be used
       );
-      ImGui::PopStyleVar ( );
+      ImGui::PopStyleVar (2);
 
       SK_RunOnce (ImGui::GetCurrentWindow()->HiddenFramesCannotSkipItems += 2);
 

--- a/src/imgui/imgui_impl_dx11.cpp
+++ b/src/imgui/imgui_impl_dx11.cpp
@@ -944,7 +944,7 @@ static void ImGui_ImplDX11_CreateFontsTexture()
   // Create texture sampler
   D3D11_SAMPLER_DESC
     sampler_desc                    = { };
-    sampler_desc.Filter             = D3D11_FILTER_MIN_MAG_MIP_POINT;
+    sampler_desc.Filter             = D3D11_FILTER_MIN_MAG_MIP_LINEAR;
     sampler_desc.AddressU           = D3D11_TEXTURE_ADDRESS_CLAMP;
     sampler_desc.AddressV           = D3D11_TEXTURE_ADDRESS_CLAMP;
     sampler_desc.AddressW           = D3D11_TEXTURE_ADDRESS_CLAMP;
@@ -1994,9 +1994,6 @@ ImGui_ImplDX11_CreateWindow (ImGuiViewport *viewport)
     
           vd->SDRWhiteLevel = SKIF_Util_GetSDRWhiteLevelForHMONITOR (vd->DXGIDesc.Monitor);
           vd->HDRLuma       = vd->DXGIDesc.MaxLuminance;
-
-          extern float SKIV_HDR_DisplayMaxLuminance;
-                       SKIV_HDR_DisplayMaxLuminance = vd->HDRLuma;
 
   #pragma region Enable HDR
           // DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709    - SDR display with no Advanced Color capabilities

--- a/src/imgui/imgui_impl_win32.cpp
+++ b/src/imgui/imgui_impl_win32.cpp
@@ -2196,8 +2196,8 @@ SKIF_ImGui_ImplWin32_SetFullscreen (int fullscreen)
         rect = mi.rcMonitor;
 
         // Seems to be required to account for the border of the window
-        rect.right  += 1;
-        rect.bottom += 1;
+        //rect.right  += 1;
+        //rect.bottom += 1;
 
         SKIF_ImGui_ImplWin32_SetDWMBorders (hwnd, DWMWCP_DONOTROUND);
       }

--- a/src/tabs/viewer.cpp
+++ b/src/tabs/viewer.cpp
@@ -2090,12 +2090,12 @@ SKIF_UI_Tab_DrawViewer (void)
       //    currently drawing into...?!
       //
       ImGui_ImplDX11_ViewportData* vd =
-        (ImGui_ImplDX11_ViewportData *)ImGui::GetMainViewport ()->PlatformUserData;
+        (ImGui_ImplDX11_ViewportData *)ImGui::GetWindowViewport ()->RendererUserData;
 
       ImGui::BeginDisabled ();
       // If vd were correct, this would be assigned here, but it's not!
       /////SKIV_HDR_DisplayMaxLuminance = vd->HDRLuma * 80.0f;
-      ImGui::SliderFloat   ("Display Luminance", &SKIV_HDR_DisplayMaxLuminance, 200.0f, 2000.0f);
+      ImGui::SliderFloat   ("Display Luminance", &vd->HDRLuma, 200.0f, 2000.0f, "%.1f %%");
       ImGui::EndDisabled   ();
 
       if ((SKIV_HDR_BrightnessScale / 100.0f) * SKIV_HDR_MaxLuminance > SKIV_HDR_DisplayMaxLuminance)

--- a/src/tabs/viewer.cpp
+++ b/src/tabs/viewer.cpp
@@ -2088,17 +2088,12 @@ SKIF_UI_Tab_DrawViewer (void)
       }
 
       // We need to get the luminance capabilities for the current viewport from DXGI
-      //
-      //  However, this does not seem to actually get the viewport for the window we are
-      //    currently drawing into...?!
-      //
       ImGui_ImplDX11_ViewportData* vd =
         (ImGui_ImplDX11_ViewportData *)ImGui::GetWindowViewport ()->RendererUserData;
 
       ImGui::BeginDisabled ();
-      // If vd were correct, this would be assigned here, but it's not!
-      /////SKIV_HDR_DisplayMaxLuminance = vd->HDRLuma * 80.0f;
-      ImGui::SliderFloat   ("Display Luminance", &vd->HDRLuma, 200.0f, 2000.0f, "%.1f %%");
+      SKIV_HDR_DisplayMaxLuminance = vd->HDRLuma;
+      ImGui::SliderFloat   ("Display Luminance", &vd->HDRLuma, 200.0f, 2000.0f, (const char *)u8"%.1f cd / m\u00b2");
       ImGui::EndDisabled   ();
 
       if ((SKIV_HDR_BrightnessScale / 100.0f) * SKIV_HDR_MaxLuminance > SKIV_HDR_DisplayMaxLuminance)

--- a/src/tabs/viewer.cpp
+++ b/src/tabs/viewer.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Andon "Kaldaien" Coleman
+// Copyright 2024 Andon "Kaldaien" Coleman
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
@@ -53,6 +53,8 @@
 #include <utility/updater.h>
 #include <utility/sk_utility.h>
 
+#include <imgui/imgui_impl_dx11.h>
+
 #define STB_IMAGE_IMPLEMENTATION
 #define STBI_WINDOWS_UTF8
 #define STBI_ONLY_JPEG
@@ -84,6 +86,15 @@ enum SKIV_HDR_VisualizationFlags
   SKIV_VIZ_FLAG_SDR_CONSIDER_OVERBRIGHT = 0x4
 };
 
+enum SKIV_HDR_TonemapType
+{
+  SKIV_TONEMAP_TYPE_NONE               = 0x0, // Let the display figure it out
+  SKIV_TONEMAP_TYPE_CLIP               = 0x1, // Truncate the image before display
+  SKIV_TONEMAP_TYPE_INFINITE_ROLLOFF   = 0x2, // Reduce to finite range (i.e. x/(1+x))
+  SKIV_TONEMAP_TYPE_NORMALIZE_TO_CLL   = 0x4, // Content range mapped to [0,1]
+  SKIV_TONEMAP_TYPE_MAP_CLL_TO_DISPLAY = 0x8  // Content range mapped to display range
+};
+
 float SKIV_HDR_SDRWhite = 80.0f;
 
 float SKIV_HDR_GamutHue_Rec709    [4] = { 1.0f, 1.0f, 1.0f, 1.0f }; // White
@@ -97,6 +108,9 @@ uint32_t SKIV_HDR_VisualizationId       = SKIV_HDR_VISUALIZTION_NONE;
 uint32_t SKIV_HDR_VisualizationFlagsSDR = 0xFFFFFFFFU;
 float    SKIV_HDR_MaxCLL                = 1.0f;
 float    SKIV_HDR_MaxLuminance          = 80.0f;
+float    SKIV_HDR_DisplayMaxLuminance   = 426.0f;
+float    SKIV_HDR_BrightnessScale       = 100.0f;
+int      SKIV_HDR_TonemapType           = SKIV_HDR_TonemapType::SKIV_TONEMAP_TYPE_MAP_CLL_TO_DISPLAY;
 
 CComPtr <ID3D11UnorderedAccessView>
          SKIV_HDR_GamutCoverageUAV      = nullptr;
@@ -999,7 +1013,7 @@ LoadLibraryTexture (image_s& image)
     XMVECTOR vMaxLum = g_XMZero;
     XMVECTOR vMinLum = g_XMOne;
 
-    double dLumAccum = 0.0;
+    float fLumAccum = 0.0f;
 
     static constexpr float FLT16_MIN = 0.0000000894069671630859375f;
 
@@ -1018,6 +1032,8 @@ LoadLibraryTexture (image_s& image)
       XMVECTOR v;
 
       uint32_t xm_test_all = 0x0;
+
+      float fScanlineLum = 0.0f;
 
       for (size_t j = 0; j < width; ++j)
       {
@@ -1102,15 +1118,14 @@ LoadLibraryTexture (image_s& image)
         vMinLum =
           XMVectorMin (vMinLum, vColorXYZ);
 
-        dLumAccum +=
+        fScanlineLum +=
           XMVectorGetY (v);
-
-        //lumTotal +=
-        //  logf ( std::max (0.000001f, 0.000001f + XMVectorGetY (v)) ),
-        //++N;
 
         pixels++;
       }
+
+      fLumAccum +=
+        (fScanlineLum / static_cast <float> (width));
     } );
 
     const float fMaxCLL =
@@ -1161,10 +1176,9 @@ LoadLibraryTexture (image_s& image)
     image.light_info.max_nits     = fMaxLum * 80.0f; // scRGB
     image.light_info.min_nits     = fMinLum * 80.0f; // scRGB
 
-    // Not a great measure of average, but it's sufficient for now
-    image.light_info.avg_nits     = 80.0f * static_cast <float> (
-      dLumAccum / static_cast <double> (meta.width * meta.height)
-    );
+    // We use the sum of averages per-scanline to help avoid overflow
+    image.light_info.avg_nits     = 80.0f *
+      (fLumAccum / static_cast <float> (meta.height));
   }
 
   HRESULT hr =
@@ -2038,6 +2052,52 @@ SKIF_UI_Tab_DrawViewer (void)
                              cover.uv1, // Bottom Right coordinates
                              ImVec4 (1.0f, 1.0f, 1.0f, 1.0f)
       );
+
+      ImGui::PopFont ();
+
+      ImGui::TextUnformatted ("\n");
+      ImGui::SliderFloat ("Brightness", &SKIV_HDR_BrightnessScale, 1.0f, 2000.0f, "%.3f %%", ImGuiSliderFlags_Logarithmic);
+
+      if (SKIV_HDR_BrightnessScale != 100.0f)
+      {
+        ImGui::SameLine ();
+        if (ImGui::Button (ICON_FA_ROTATE_LEFT "###Brightness_Reset")) SKIV_HDR_BrightnessScale = 100.0f;
+      }
+
+      // We need to get the luminance capabilities for the current viewport from DXGI
+      //
+      //  However, this does not seem to actually get the viewport for the window we are
+      //    currently drawing into...?!
+      //
+      ImGui_ImplDX11_ViewportData* vd =
+        (ImGui_ImplDX11_ViewportData *)ImGui::GetWindowViewport ()->PlatformUserData;
+
+      ImGui::BeginDisabled ();
+      // If vd were correct, this would be assigned here, but it's not!
+      /////SKIV_HDR_DisplayMaxLuminance = vd->HDRLuma * 80.0f;
+      ImGui::SliderFloat   ("Display Luminance", &SKIV_HDR_DisplayMaxLuminance, 200.0f, 2000.0f);
+      ImGui::EndDisabled   ();
+
+      if ((SKIV_HDR_BrightnessScale / 100.0f) * SKIV_HDR_MaxLuminance > SKIV_HDR_DisplayMaxLuminance)
+      {
+        ImGui::TextUnformatted ("\n");
+        ImGui::TextColored (ImColor (0xff0099ff), ICON_FA_TRIANGLE_EXCLAMATION);
+        ImGui::SameLine    ();
+        ImGui::TextUnformatted ("Content Exceeds Display Capabilities");
+
+        ImGui::RadioButton ("Do Nothing",      &SKIV_HDR_TonemapType, SKIV_TONEMAP_TYPE_NONE);
+        ImGui::SameLine ();
+        ImGui::RadioButton ("Clip to Display", &SKIV_HDR_TonemapType, SKIV_TONEMAP_TYPE_CLIP);
+        ImGui::SameLine ();
+        // SDR tonemapping needs more testing
+#if 0
+        ImGui::RadioButton ("Map to SDR",      &SKIV_HDR_TonemapType, SKIV_TONEMAP_TYPE_NORMALIZE_TO_CLL);
+        ImGui::SameLine ();
+#endif
+        ImGui::RadioButton ("Map to Display",  &SKIV_HDR_TonemapType, SKIV_TONEMAP_TYPE_MAP_CLL_TO_DISPLAY);
+      }
+
+      ImGui::PushFont (fontConsolas);
 
       if (SKIV_HDR_VisualizationId == SKIV_HDR_VISUALIZTION_SDR)
       {

--- a/src/tabs/viewer.cpp
+++ b/src/tabs/viewer.cpp
@@ -1321,12 +1321,15 @@ GetCurrentAspectRatio (image_s& image)
   // Fill / "Fill window"
   else if (_appliedScaling == ImageScaling_Fill)
   {
+    /* We shouldn't have visible scrollbars since
+       no other image viewer cares about that anyway...
     // Workaround to prevent content/frame fighting one another
     if (ImGui::GetScrollMaxY() == 0.0f)
       avail_width -= ImGui::GetStyle().ScrollbarSize;
 
     if (ImGui::GetScrollMaxX() == 0.0f)
       avail_height -= ImGui::GetStyle().ScrollbarSize;
+    */
 
     // Fill the content area
     if (contentAspectRatio > frameAspectRatio)

--- a/src/tabs/viewer.cpp
+++ b/src/tabs/viewer.cpp
@@ -2090,7 +2090,7 @@ SKIF_UI_Tab_DrawViewer (void)
       //    currently drawing into...?!
       //
       ImGui_ImplDX11_ViewportData* vd =
-        (ImGui_ImplDX11_ViewportData *)ImGui::GetWindowViewport ()->PlatformUserData;
+        (ImGui_ImplDX11_ViewportData *)ImGui::GetMainViewport ()->PlatformUserData;
 
       ImGui::BeginDisabled ();
       // If vd were correct, this would be assigned here, but it's not!

--- a/src/tabs/viewer.cpp
+++ b/src/tabs/viewer.cpp
@@ -1925,6 +1925,26 @@ SKIF_UI_Tab_DrawViewer (void)
         ImGui::TextUnformatted ("\n");
     }
 
+    // Pure additional Developer Mode debug data
+    if (_registry.bDeveloperMode)
+    {
+      char     szLabels      [512] = { };
+      char     szLabelsData  [512] = { };
+
+      sprintf (szLabels,     "Viewport Size:\n"
+                             "Frame Size:\n");
+      sprintf (szLabelsData, "%.0fx%.0f\n"
+                             "%.0fx%.0f\n", 
+                              ImGui::GetMainViewport ( )->Size.x,
+                              ImGui::GetMainViewport ( )->Size.y,
+                              cover.avail_size.x,
+                              cover.avail_size.y);
+
+      ImGui::TextUnformatted (szLabels);
+      ImGui::SameLine        (posXvalues);
+      ImGui::TextUnformatted (szLabelsData);
+    }
+
     // Basic Image Details
     {
       static const char szLabels [] = "Resolution:\n"


### PR DESCRIPTION
I have added support for tone mapping HDR content that exceeds the current display's capabilities.

The current implementation is attempting to match, exactly, what Chromium is documented as doing for HDR Content Range to Display Range mapping.


I had to slightly modify the ImGui D3D11 backend, to expose the definition of the Platform Viewport Data. Unfortunately, even after doing that, it seems I cannot get the correct viewport for the ImGui window being drawn into.

If you could take a look at the commented section in **viewer.cpp** discussing `vd` while reviewing the code changes, that would be really great.